### PR TITLE
Fix build and tweak JSON output

### DIFF
--- a/main.c
+++ b/main.c
@@ -25,6 +25,7 @@
 	#define mkdir(path, mode) mkdir(path)
 #endif
 
+#define TITLE "ird_tools v0.7\n\n"
 
 u8 verbose=0;
 u8 get_data;
@@ -369,9 +370,9 @@ void IRD_extract(char *IRD_PATH)
 		sprintf(msg, "\t\t\t\"START\": %u,\n",	ird->RegionHashes[i].Start); fputs(msg, json);
 		sprintf(msg, "\t\t\t\"END\": %u,\n",	ird->RegionHashes[i].End); fputs(msg, json);
 		if( plain ) {
-			fputs("\t\t\t\"TYPE\" : \"Plain\",\n", json);
+			fputs("\t\t\t\"TYPE\" : \"Plain\"\n", json);
 		} else {
-			fputs("\t\t\t\"TYPE\" : \"Encrypted\",\n", json);
+			fputs("\t\t\t\"TYPE\" : \"Encrypted\"\n", json);
 		}
 
 		sprintf(msg, " %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X | %-20d |\n",


### PR DESCRIPTION
This fixes two issues that I personally ran into:
- Readding `#define TITLE` (see #1 and [8e2c4b8#commitcomment-64008427](https://github.com/Zarh/ird_tools/commit/8e2c4b88ab37552a974ec3e40b7bc1dae13c9c41#commitcomment-64008427))
    - Previously broke build as [`main.c#L683`](https://github.com/Zarh/ird_tools/blob/main/main.c#L683) tries to print the version number of the app and (of course) fails.

- Removing a comma after the Partition "Type" section of the JSON output
    - Previously broke parsing the JSON as it expected more keys after that output (which of course aren't there) with `jq`'s error
message being `parse error: Expected another key-value pair at line 17988, column 3`
